### PR TITLE
logger: expose format()

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -33,6 +33,7 @@ class Logger {
     this.filename = null;
     this.stream = null;
     this.contexts = Object.create(null);
+    this.fmt = format;
 
     if (options)
       this.set(options);


### PR DESCRIPTION
See https://github.com/bcoin-org/blgr/commit/fddba976b0ffd21f25a3b1679c8ebba6c039d3e6

That change broke the bcoin in-browser app here:
https://github.com/bcoin-org/bcoin/blob/master/browser/src/app.js#L31

This pull request exposes the new custom format module as a method of `logger` so the line in /browser/src/app.js will execute without error.

See also my branch addressing updates to bcoin-browser:
https://github.com/pinheadmz/bcoin/commits/browser