### PR TITLE
Always show stack trace on errors

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -514,12 +514,11 @@ class Logger {
     if (level !== Logger.levels.ERROR)
       msg = `Error: ${msg}`;
 
-    this.log(level, module, [msg]);
+    // Strip first line of stack (same as err.message)
+    if (err.stack)
+      msg += '\n' + String(err.stack).split('\n').slice(1).join('\n');
 
-    if (level <= Logger.levels.WARNING) {
-      if (this.stream)
-        this.stream.write(err.stack + '\n');
-    }
+    this.log(level, module, [msg]);
   }
 
   /**


### PR DESCRIPTION
**Issue**
Assertion errors are difficult to debug.
In bcoin it's common to see errors such as this in logs:
`[error] (node) false == true` or
`[error] (node) Assertion failed.`

Without a stack trace it is impossible to determine the cause of these errors.
We don't want a stack trace to show for every error thrown, but assertions
are an exception.

**Solution**
Using `ERR_ASSERTION` code to always show stack trace in this case.

Was hoping for a more general solution than relying on error code,
but I've decided it makes sense to consider assertions a special
exception case that we should handle specifically.

Example result after change:
```
[error] (node) Assertion failed.
    at parseEntry (bcoin/lib/wallet/client.js:87:3)
    at WalletClient.getEntry (bcoin/lib/wallet/client.js:63:12)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)
```

**Caveat:**
This does result in duplicate stack traces showing in stream due to this line:
https://github.com/bcoin-org/blgr/blob/f4de8ba5a5a6fac6ef4dffccaf53ab7d13551f77/lib/logger.js#L524-L527
I'm not sure what the best solution is yet, short of adding a `code !== 'ERR_ASSERTION'` check,
but there could be some consequences here.

**Related discussions:**
https://github.com/bcoin-org/bcoin/issues/762#issuecomment-488728119
https://github.com/bcoin-org/bcoin/pull/605/files#r256155372