### PR TITLE
Truncate log file during operation

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -179,15 +179,20 @@ class Logger {
         this.truncating = false;
         return;
       }
-      this.debug('Truncating log file to %dmb.', mb(maxSize));
-
       const fd = await fs.open(this.filename, 'r+');
       const data = Buffer.allocUnsafe(maxSize);
 
       await fs.read(fd, data, 0, maxSize, stat.size - maxSize);
-      await fs.ftruncate(fd, maxSize);
-      await fs.write(fd, data, 0, maxSize, 0);
+
+      // ASCII code for `\n`
+      const start = Math.max(data.indexOf(0x0a), 0);
+      const end = data.lastIndexOf(0x0a);
+      const trim = data.subarray(start, end + 1);
+
+      await fs.ftruncate(fd, trim.byteLength);
+      await fs.write(fd, trim);
       await fs.close(fd);
+
       this._bytesSinceTruncate = 0;
     } finally {
       this.truncating = false;
@@ -481,6 +486,9 @@ class Logger {
    */
 
   writeStream(level, module, args) {
+    if (this.truncating)
+      return;
+
     const name = Logger.prefixByVal[level];
 
     assert(name, 'Invalid log level.');

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -34,6 +34,9 @@ class Logger {
     this.stream = null;
     this.contexts = Object.create(null);
     this.fmt = format;
+    this.truncating = false;
+
+    this._bytesSinceTruncate = 0;
 
     if (options)
       this.set(options);
@@ -148,37 +151,47 @@ class Logger {
    */
 
   async truncate() {
+    if (this.truncating)
+      return;
+
     if (!this.filename)
       return;
 
     if (fs.unsupported)
       return;
 
-    assert(!this.stream);
+    this.truncating = true;
 
     let stat;
     try {
       stat = await fs.stat(this.filename);
     } catch (e) {
+      this.truncating = false;
       if (e.code === 'ENOENT')
         return;
       throw e;
     }
 
-    const maxSize = Logger.MAX_FILE_SIZE;
+    try {
+      const maxSize = Logger.MAX_FILE_SIZE;
 
-    if (stat.size <= maxSize + (maxSize / 10))
-      return;
+      if (stat.size <= maxSize + Logger.TRUNCATE_THRESHOLD) {
+        this.truncating = false;
+        return;
+      }
+      this.debug('Truncating log file to %dmb.', mb(maxSize));
 
-    this.debug('Truncating log file to %dmb.', mb(maxSize));
+      const fd = await fs.open(this.filename, 'r+');
+      const data = Buffer.allocUnsafe(maxSize);
 
-    const fd = await fs.open(this.filename, 'r+');
-    const data = Buffer.allocUnsafe(maxSize);
-
-    await fs.read(fd, data, 0, maxSize, stat.size - maxSize);
-    await fs.ftruncate(fd, maxSize);
-    await fs.write(fd, data, 0, maxSize, 0);
-    await fs.close(fd);
+      await fs.read(fd, data, 0, maxSize, stat.size - maxSize);
+      await fs.ftruncate(fd, maxSize);
+      await fs.write(fd, data, 0, maxSize, 0);
+      await fs.close(fd);
+      this._bytesSinceTruncate = 0;
+    } finally {
+      this.truncating = false;
+    }
   }
 
   /**
@@ -488,7 +501,11 @@ class Logger {
     msg += format(args, false);
     msg += '\n';
 
-    this.stream.write(msg);
+    this.stream.write(msg, () => {
+      this._bytesSinceTruncate += msg.length;
+      if (this._bytesSinceTruncate >= Logger.TRUNCATE_THRESHOLD)
+        this.truncate();
+    });
   }
 
   /**
@@ -791,6 +808,14 @@ Logger.HAS_TTY = Boolean(process.stdout && process.stdout.isTTY);
  */
 
 Logger.MAX_FILE_SIZE = 20 << 20;
+
+/**
+ * Amount of bytes above MAX_FILE_SIZE to allow before truncating.
+ * @const {Number}
+ * @default
+ */
+
+Logger.TRUNCATE_THRESHOLD = Logger.MAX_FILE_SIZE / 10;
 
 /**
  * Available log levels.

--- a/test/logger-test.js
+++ b/test/logger-test.js
@@ -4,7 +4,18 @@
 'use strict';
 
 const assert = require('bsert');
+const {tmpdir} = require('os');
+const Path = require('path');
+const fs = require('fs');
+const pfs = require('../lib/fs'); // Has promisified stat, but no mkdir
 const Logger = require('../lib/logger');
+
+function tempFile(name) {
+  const time = Date.now();
+  const dir = Path.join(tmpdir(), `blgr-test-${time}`);
+  fs.mkdirSync(dir);
+  return Path.join(dir, `${name}.log`);
+};
 
 describe('Logger', function() {
   describe('log', function() {
@@ -241,6 +252,43 @@ describe('Logger', function() {
       assert.equal(called.level, Logger.levels.SPAM);
       assert.equal(called.args.length, 1);
       checkMsg(called.args[0], true, false);
+    });
+  });
+
+  describe('file size', function() {
+    const actualSize = Logger.MAX_FILE_SIZE;
+    const actualThreshold = Logger.TRUNCATE_THRESHOLD;
+    const testSize = 1 * 1000 * 1000; // 1 MiB
+    const testThreshold = testSize / 10;
+    const filename = tempFile('file-size');
+    let logger;
+
+    before(async () => {
+      Logger.MAX_FILE_SIZE = testSize;
+      Logger.TRUNCATE_THRESHOLD = testThreshold;
+
+      logger = new Logger({
+        level: 'spam',
+        filename: filename,
+        console: false
+      });
+      await logger.open();
+    });
+
+    after(async () => {
+      await logger.close();
+      Logger.MAX_FILE_SIZE = actualSize;
+      Logger.TRUNCATE_THRESHOLD = actualThreshold;
+    });
+
+    it('should keep log file under the size limit while running', async () => {
+      for (let i = 0; i < 10000; i++) {
+        logger.debug(`${i}`);
+        // 500 bytes = 1000 char hex = 1000 bytes written to log file
+        logger.debug(Buffer.alloc(500).toString('hex'));
+      }
+      const stat = await pfs.stat(filename);
+      assert(stat.size <= (testSize + testThreshold));
     });
   });
 });


### PR DESCRIPTION
I'm not sure if this is exactly the best approach but something needs to be done to this package to prevent DoS attacks by disk-filling the log. Recently on the Handshake network a few of us with `log-level: spam` were crashed by a pathological node on the network that repeatedly broadcast 10,000 orphan transactions. Currently `blgr` only truncates the log file during `open()`. Meaning if you are lucky enough never to have to restart your node, the log file will never stop growing.