### PR TITLE
Rotate log files and prune oldest archival files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ logger.warning('world');
 logger.error('!');
 ```
 
+## Changelog
+
+The `shrink` property has been removed, as well as the `truncate()` function.
+Instead of deleting historical information from the log file at open, logger
+will now "rotate" the log file when the file size reaches `MAX_FILE_SIZE`
+(default about 20 MB). At that time, the file will be rotated out and
+timestamped, and a new log file will be created. When the number of archival log
+files reaches `MAX_ARCHIVAL_FILES` (default 10), the oldest archival files will
+be removed from disk.
+
 ## Contribution and License Agreement
 
 If you contribute code to this project, you are implicitly allowing your code

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -29,3 +29,4 @@ exports.write = promisify(fs.write);
 exports.ftruncate = promisify(fs.ftruncate);
 exports.createWriteStream = fs.createWriteStream;
 exports.mkdir = promisify(fs.mkdir);
+exports.rename = promisify(fs.rename);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -28,3 +28,4 @@ exports.read = promisify(fs.read);
 exports.write = promisify(fs.write);
 exports.ftruncate = promisify(fs.ftruncate);
 exports.createWriteStream = fs.createWriteStream;
+exports.mkdir = promisify(fs.mkdir);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -32,3 +32,4 @@ exports.mkdir = promisify(fs.mkdir);
 exports.rename = promisify(fs.rename);
 exports.readdir = promisify(fs.readdir);
 exports.stat = promisify(fs.stat);
+exports.unlink = promisify(fs.unlink);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -30,3 +30,5 @@ exports.ftruncate = promisify(fs.ftruncate);
 exports.createWriteStream = fs.createWriteStream;
 exports.mkdir = promisify(fs.mkdir);
 exports.rename = promisify(fs.rename);
+exports.readdir = promisify(fs.readdir);
+exports.stat = promisify(fs.stat);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-const path = require('path');
+const Path = require('path');
 const assert = require('bsert');
 const format = require('./format');
 const fs = require('./fs');
@@ -28,12 +28,12 @@ class Logger {
     this.level = Logger.levels.NONE;
     this.colors = Logger.HAS_TTY;
     this.maxFileSize = Logger.MAX_FILE_SIZE;
+    this.maxFiles = Logger.MAX_ARCHIVAL_FILES;
     this.console = true;
     this.shrink = true;
     this.closed = true;
     this.closing = false;
     this.filename = null;
-    this.dirname = null;
     this.stream = null;
     this.contexts = Object.create(null);
     this.fmt = format;
@@ -82,12 +82,16 @@ class Logger {
     if (options.filename != null) {
       assert(typeof options.filename === 'string', 'Bad file.');
       this.filename = options.filename;
-      this.dirname = path.dirname(this.filename);
     }
 
     if (options.maxFileSize != null) {
       assert((options.maxFileSize >>> 0) === options.maxFileSize);
       this.maxFileSize = options.maxFileSize;
+    }
+
+    if (options.maxFiles != null) {
+      assert((options.maxFiles >>> 0) === options.maxFiles);
+      this.maxFiles = options.maxFiles;
     }
   }
 
@@ -217,10 +221,11 @@ class Logger {
     await this.close();
 
     // Current log file is closed. Rename it.
-    const dot = this.filename.lastIndexOf('.');
-    const path = this.filename.substr(0, dot);
-    const ext = this.filename.substr(dot);
-    const rename = path + '_' + dateString() + ext;
+    const ext = Path.extname(this.filename);
+    const base = Path.basename(this.filename, ext);
+    const dir = Path.dirname(this.filename);
+
+    const rename = Path.join(dir, base + '_' + dateString() + ext);
 
     await fs.rename(this.filename, rename);
 
@@ -228,7 +233,39 @@ class Logger {
 
     this.rotating = false;
 
+    this.prune(dir, base, ext);
+
     return rename;
+  }
+
+  /**
+   * Remove old log files
+   * @method
+   * @private
+   * @param {String} dir
+   * @param {String} base
+   * @param {String} ext
+   * @returns {Promise} - Returns Number
+   */
+
+  async prune(dir, base, ext) {
+    // Find all the archival files in the target directory
+    const files = await fs.readdir(dir);
+    const re = new RegExp(`${base}_.*${ext}`);
+    const oldFiles = files.filter(filename => re.test(filename));
+
+    if (oldFiles.length <= this.maxFiles)
+      return;
+
+    // Archival files are named with year-month-day-hour-min-sec
+    // so they should already be in order from oldest to newest.
+    // But just in case readdir() isn't reliable for this...
+    oldFiles.sort();
+
+    const prune = oldFiles.slice(0, -1 * this.maxFiles);
+
+    for (const file of prune)
+      await fs.unlink(Path.join(dir, file));
   }
 
   /**
@@ -318,7 +355,6 @@ class Logger {
     assert(typeof filename === 'string');
     assert(!this.stream, 'Log stream has already been created.');
     this.filename = filename;
-    this.dirname = path.dirname(this.filename);
   }
 
   /**
@@ -866,6 +902,14 @@ Logger.HAS_TTY = Boolean(process.stdout && process.stdout.isTTY);
  */
 
 Logger.MAX_FILE_SIZE = 20 << 20;
+
+/**
+ * Maximum number of archival log files to keep on disk.
+ * @const {Number}
+ * @default
+ */
+
+Logger.MAX_ARCHIVAL_FILES = 10;
 
 /**
  * Available log levels.

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -30,7 +30,6 @@ class Logger {
     this.maxFileSize = Logger.MAX_FILE_SIZE;
     this.maxFiles = Logger.MAX_ARCHIVAL_FILES;
     this.console = true;
-    this.shrink = true;
     this.closed = true;
     this.closing = false;
     this.filename = null;
@@ -75,11 +74,6 @@ class Logger {
       this.console = options.console;
     }
 
-    if (options.shrink != null) {
-      assert(typeof options.shrink === 'boolean');
-      this.shrink = options.shrink;
-    }
-
     if (options.filename != null) {
       assert(typeof options.filename === 'string', 'Bad file.');
       this.filename = options.filename;
@@ -117,9 +111,6 @@ class Logger {
       this.closed = false;
       return;
     }
-
-    if (this.shrink)
-      await this.truncate();
 
     this._fileSize = await this.getSize();
 
@@ -159,45 +150,6 @@ class Logger {
     this._fileSize = 0;
 
     this.closed = true;
-  }
-
-  /**
-   * Truncate the log file to the last 20mb.
-   * @method
-   * @private
-   * @returns {Promise}
-   */
-
-  async truncate() {
-    if (!this.filename)
-      return;
-
-    if (fs.unsupported)
-      return;
-
-    assert(!this.stream);
-
-    let stat;
-    try {
-      stat = await fs.stat(this.filename);
-    } catch (e) {
-      if (e.code === 'ENOENT')
-        return;
-      throw e;
-    }
-
-    if (stat.size <= this.maxFileSize + (this.maxFileSize / 10))
-      return;
-
-    this.debug('Truncating log file to %dmb.', mb(this.maxFileSize));
-
-    const fd = await fs.open(this.filename, 'r+');
-    const data = Buffer.allocUnsafe(this.maxFileSize);
-
-    await fs.read(fd, data, 0, this.maxFileSize, stat.size - this.maxFileSize);
-    await fs.ftruncate(fd, this.maxFileSize);
-    await fs.write(fd, data, 0, this.maxFileSize, 0);
-    await fs.close(fd);
   }
 
   /**

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,6 +6,7 @@
 
 'use strict';
 
+const path = require('path');
 const assert = require('bsert');
 const format = require('./format');
 const fs = require('./fs');
@@ -26,11 +27,13 @@ class Logger {
   constructor(options) {
     this.level = Logger.levels.NONE;
     this.colors = Logger.HAS_TTY;
+    this.maxFileSize = Logger.MAX_FILE_SIZE;
     this.console = true;
     this.shrink = true;
     this.closed = true;
     this.closing = false;
     this.filename = null;
+    this.dirname = null;
     this.stream = null;
     this.contexts = Object.create(null);
     this.fmt = format;
@@ -79,6 +82,12 @@ class Logger {
     if (options.filename != null) {
       assert(typeof options.filename === 'string', 'Bad file.');
       this.filename = options.filename;
+      this.dirname = path.dirname(this.filename);
+    }
+
+    if (options.maxFileSize != null) {
+      assert((options.maxFileSize >>> 0) === options.maxFileSize);
+      this.maxFileSize = options.maxFileSize;
     }
   }
 
@@ -172,19 +181,17 @@ class Logger {
       throw e;
     }
 
-    const maxSize = Logger.MAX_FILE_SIZE;
-
-    if (stat.size <= maxSize + (maxSize / 10))
+    if (stat.size <= this.maxFileSize + (this.maxFileSize / 10))
       return;
 
-    this.debug('Truncating log file to %dmb.', mb(maxSize));
+    this.debug('Truncating log file to %dmb.', mb(this.maxFileSize));
 
     const fd = await fs.open(this.filename, 'r+');
-    const data = Buffer.allocUnsafe(maxSize);
+    const data = Buffer.allocUnsafe(this.maxFileSize);
 
-    await fs.read(fd, data, 0, maxSize, stat.size - maxSize);
-    await fs.ftruncate(fd, maxSize);
-    await fs.write(fd, data, 0, maxSize, 0);
+    await fs.read(fd, data, 0, this.maxFileSize, stat.size - this.maxFileSize);
+    await fs.ftruncate(fd, this.maxFileSize);
+    await fs.write(fd, data, 0, this.maxFileSize, 0);
     await fs.close(fd);
   }
 
@@ -207,7 +214,7 @@ class Logger {
 
     this.rotating = true;
 
-    await closeStream(this.stream);
+    await this.close();
 
     // Current log file is closed. Rename it.
     const dot = this.filename.lastIndexOf('.');
@@ -217,15 +224,8 @@ class Logger {
 
     await fs.rename(this.filename, rename);
 
-    try {
-      this.stream = await openStream(this.filename);
-    } catch (e) {
-      this.retry();
-      return null;
-    }
-    this.stream.once('error', e => this.handleError(e));
+    await this.open();
 
-    this._fileSize = 0;
     this.rotating = false;
 
     return rename;
@@ -318,6 +318,7 @@ class Logger {
     assert(typeof filename === 'string');
     assert(!this.stream, 'Log stream has already been created.');
     this.filename = filename;
+    this.dirname = path.dirname(this.filename);
   }
 
   /**
@@ -559,11 +560,10 @@ class Logger {
     msg += format(args, false);
     msg += '\n';
 
+    this.stream.write(msg);
     this._fileSize += msg.length;
-    this.stream.write(msg, () => {
-      if (this._fileSize >= Logger.MAX_FILE_SIZE)
-        this.rotate();
-    });
+    if (this._fileSize >= this.maxFileSize)
+      this.rotate();
   }
 
   /**

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -35,6 +35,8 @@ class Logger {
     this.contexts = Object.create(null);
     this.fmt = format;
 
+    this._fileSize = 0;
+
     if (options)
       this.set(options);
   }
@@ -104,6 +106,8 @@ class Logger {
     if (this.shrink)
       await this.truncate();
 
+    this._fileSize = await this.getSize();
+
     this.stream = await openStream(this.filename);
     this.stream.once('error', this.handleError.bind(this));
     this.closed = false;
@@ -136,6 +140,8 @@ class Logger {
       }
       this.stream = null;
     }
+
+    this._fileSize = 0;
 
     this.closed = true;
   }
@@ -179,6 +185,24 @@ class Logger {
     await fs.ftruncate(fd, maxSize);
     await fs.write(fd, data, 0, maxSize, 0);
     await fs.close(fd);
+  }
+
+  /**
+   * Get the size of the current log file in bytes.
+   * @method
+   * @private
+   * @returns {Promise} - Returns Number
+   */
+
+  async getSize() {
+    try {
+      const stat = await fs.stat(this.filename);
+      return stat.size;
+    } catch (e) {
+      if (e.code === 'ENOENT')
+        return 0;
+      throw e;
+    }
   }
 
   /**
@@ -488,6 +512,7 @@ class Logger {
     msg += format(args, false);
     msg += '\n';
 
+    this._fileSize += msg.length;
     this.stream.write(msg);
   }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -40,6 +40,7 @@ class Logger {
     this.rotating = false;
 
     this._fileSize = 0;
+    this._buffer = [];
 
     if (options)
       this.set(options);
@@ -231,8 +232,13 @@ class Logger {
 
     await this.open();
 
-    this.rotating = false;
+    while (this._buffer.length > 0) {
+      const msg = this._buffer.shift();
+      this.stream.write(msg);
+      this._fileSize += msg.length;
+    }
 
+    this.rotating = false;
     this.prune(dir, base, ext);
 
     return rename;
@@ -477,7 +483,7 @@ class Logger {
    */
 
   log(level, module, args) {
-    if (this.closed)
+    if (this.closed && !this.rotating)
       return;
 
     if (this.level < level)
@@ -573,17 +579,14 @@ class Logger {
    */
 
   writeStream(level, module, args) {
-    if (this.rotating)
-      return;
-
     const name = Logger.prefixByVal[level];
 
     assert(name, 'Invalid log level.');
 
-    if (!this.stream)
+    if (!this.stream && !this.rotating)
       return;
 
-    if (this.closing)
+    if (this.closing && !this.rotating)
       return;
 
     const date = new Date().toISOString().slice(0, -5) + 'Z';
@@ -596,10 +599,14 @@ class Logger {
     msg += format(args, false);
     msg += '\n';
 
-    this.stream.write(msg);
-    this._fileSize += msg.length;
-    if (this._fileSize >= this.maxFileSize)
-      this.rotate();
+    if (this.rotating) {
+      this._buffer.push(msg);
+    } else {
+      this.stream.write(msg);
+      this._fileSize += msg.length;
+      if (this._fileSize >= this.maxFileSize)
+        this.rotate();
+    }
   }
 
   /**
@@ -612,7 +619,7 @@ class Logger {
    */
 
   logError(level, module, err) {
-    if (this.closed)
+    if (this.closed && !this.rotating)
       return;
 
     if (fs.unsupported && this.console) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -34,6 +34,7 @@ class Logger {
     this.stream = null;
     this.contexts = Object.create(null);
     this.fmt = format;
+    this.rotating = false;
 
     this._fileSize = 0;
 
@@ -185,6 +186,49 @@ class Logger {
     await fs.ftruncate(fd, maxSize);
     await fs.write(fd, data, 0, maxSize, 0);
     await fs.close(fd);
+  }
+
+  /**
+   * Rotate out the current log file.
+   * @method
+   * @private
+   * @returns {Promise} - Returns String
+   */
+
+  async rotate() {
+    if (this.rotating)
+      return null;
+
+    if (!this.filename)
+      return null;
+
+    if (fs.unsupported)
+      return null;
+
+    this.rotating = true;
+
+    await closeStream(this.stream);
+
+    // Current log file is closed. Rename it.
+    const dot = this.filename.lastIndexOf('.');
+    const path = this.filename.substr(0, dot);
+    const ext = this.filename.substr(dot);
+    const rename = path + '_' + dateString() + ext;
+
+    await fs.rename(this.filename, rename);
+
+    try {
+      this.stream = await openStream(this.filename);
+    } catch (e) {
+      this.retry();
+      return null;
+    }
+    this.stream.once('error', e => this.handleError(e));
+
+    this._fileSize = 0;
+    this.rotating = false;
+
+    return rename;
   }
 
   /**
@@ -492,6 +536,9 @@ class Logger {
    */
 
   writeStream(level, module, args) {
+    if (this.rotating)
+      return;
+
     const name = Logger.prefixByVal[level];
 
     assert(name, 'Invalid log level.');
@@ -513,7 +560,10 @@ class Logger {
     msg += '\n';
 
     this._fileSize += msg.length;
-    this.stream.write(msg);
+    this.stream.write(msg, () => {
+      if (this._fileSize >= Logger.MAX_FILE_SIZE)
+        this.rotate();
+    });
   }
 
   /**
@@ -947,6 +997,16 @@ function closeStream(stream) {
 
     stream.close();
   });
+}
+
+function dateString() {
+  // '2019-10-28T19:02:45.122Z'
+  let now = new Date().toJSON();
+
+  // '2019-10-28_19-01-15'
+  now = now.replace(/:/g,'-').replace('T','_').slice(0,-5);
+
+  return now;
 }
 
 /*

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1047,8 +1047,8 @@ function dateString() {
   // '2019-10-28T19:02:45.122Z'
   let now = new Date().toJSON();
 
-  // '2019-10-28_19-01-15'
-  now = now.replace(/:/g,'-').replace('T','_').slice(0,-5);
+  // '2019-10-28_19-01-15-122'
+  now = now.replace(/:/g,'-').replace('T','_').replace('.','-').slice(0,-1);
 
   return now;
 }

--- a/test/logger-test.js
+++ b/test/logger-test.js
@@ -22,13 +22,16 @@ function logLines(logger, lines) {
   let perLine = 0;
   perLine += '[D:2019-10-21T19:58:44Z] '.length; // timestamp
   perLine += 1;                                  // \n end of every line
-  perLine += 1000;                               // the "message"
+  perLine += 14;                                 // Date.now() plus space
+  perLine += 1000;                               // 500 byte Buffer.toString()
 
   for (let i = 0; i < lines; i++) {
-    // 500 byte buffer -> 1000 char hex -> 1000 bytes written to log file
-    logger.debug(Buffer.alloc(500).toString('hex'));
+    logger.debug(
+      Date.now().toString()
+      + ' '
+      + Buffer.alloc(500).toString('hex')
+    );
   }
-
   return perLine * lines;
 };
 

--- a/test/logger-test.js
+++ b/test/logger-test.js
@@ -274,7 +274,7 @@ describe('Logger', function() {
   });
 
  describe('File rotation', function() {
-    this.timeout(30000);
+    this.timeout(5000);
     let filename;
     let logger;
 
@@ -332,6 +332,7 @@ describe('Logger', function() {
 
     it('should rotate out log files when limit is reached', async () => {
       logger.maxFileSize = 1 << 18; // ~260kB
+      logger.maxFiles = 100; // effectively disable pruning
 
       let bytes = 0;
       for (let i = 0; i < 1000; i++) {
@@ -339,7 +340,7 @@ describe('Logger', function() {
         // In practice, we wouldn't be logging thousands of lines in a
         // single operation. Slow down the test loop so that writeStream()
         // has a chance to flush to disk and rotate the file out.
-        await new Promise(r => setTimeout(r, 5));
+        await new Promise(r => setTimeout(r, 0));
       }
 
       await logger.close();
@@ -365,7 +366,7 @@ describe('Logger', function() {
 
       for (let i = 0; i < 2000; i++) {
         logLines(logger, 1);
-        await new Promise(r => setTimeout(r, 5));
+        await new Promise(r => setTimeout(r, 0));
       }
 
       await logger.close();


### PR DESCRIPTION
API changes:

`Logger` now parses two extra options:
- `maxFileSize` (default `20 << 20` or ~20 MB): The maximum file size allowed before starting a new file.
- `maxFiles` (default `10`): The number of archival files to keep on disk (older files are pruned)

Behavior changes:

`Logger` now keeps track of how much data is being written to the current log file. When that data reaches the `maxFileSize`, the new method `rotate()` is called. `rotate()` CLOSES the logger, renames the current log file, and then REOPENS the logger with a fresh `debug.log` file of 0 bytes. The archival file is renamed with the current timestamp, e.g. `debug_2019-10-30_14-49-23.log`. Once the rotation is complete, a new method `prune()` is called. `prune()` gets the names of all the files in the `prefix` directory that match the above naming scheme by regex. The archival files are sorted alphabetically which (due to the timestamps) will be sorted oldest to newest. The newest files up to `maxFiles` are kept and the rest are deleted from disk.

Result:

I ran `hsd` with a modified version of this branch, restricting `maxFileSize` to `1 << 20` and `maxFiles` to `4`. After finishing sync on testnet my data directory looked like this:

```
$ ls -lah
total 9648
drwxr-xr-x  12 matthewzipkin  staff   384B Oct 30 10:50 .
drwxr-xr-x  11 matthewzipkin  staff   352B Oct 30 10:48 ..
drwxr-xr-x  47 matthewzipkin  staff   1.5K Oct 30 10:49 chain
-rw-r--r--   1 matthewzipkin  staff   613K Oct 30 10:50 debug.log
-rw-r--r--   1 matthewzipkin  staff   1.0M Oct 30 10:49 debug_2019-10-30_14-49-18.log
-rw-r--r--   1 matthewzipkin  staff   1.0M Oct 30 10:49 debug_2019-10-30_14-49-23.log
-rw-r--r--   1 matthewzipkin  staff   1.0M Oct 30 10:49 debug_2019-10-30_14-49-34.log
-rw-r--r--   1 matthewzipkin  staff   1.0M Oct 30 10:49 debug_2019-10-30_14-49-49.log
-rw-r--r--   1 matthewzipkin  staff    30K Oct 30 10:50 hosts.json
-rw-r--r--   1 matthewzipkin  staff    65B Oct 30 10:48 key
drwxr-x---   5 matthewzipkin  staff   160B Oct 30 10:48 tree
drwxr-xr-x   7 matthewzipkin  staff   224B Oct 30 10:48 wallet
```

Known issue:

When `logger` is rotating, messages can not be written to disk and are just lost. During IBD, messages are actually being written so fast that with extreme settings like my example above, several lines are completely lost in between files. (I estimate around 10 lines were lost based on what was kept at the end of one file and the beginning of the next). I don't think this issue will be too devastating in practice however, given the default `maxFileSize` and how rarely a rotation will occur. Users can use the new options to prevent rotation altogether. Using the included test, I was able to determine that on my system at least, a 5ms pause between log lines is all it took to not lose any data between files.